### PR TITLE
update BuildMojo to be threadsafe & fix broken test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+This is a temporary fork  (hopefully).  We have NO intention of keeping this forked repository active any longer than 
+needed.  Current items included are:
+* In-flight 0.45 items from the source repository
+* https://github.com/fabric8io/docker-maven-plugin/issues/1804 - allow use of default driver with buildx
+
 # docker-maven-plugin
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.fabric8/docker-maven-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/io.fabric8/docker-maven-plugin/)

--- a/pom.xml
+++ b/pom.xml
@@ -367,10 +367,10 @@
             <sourceDirectory>src/main/asciidoc</sourceDirectory>
             <attributes>
               <icons>font</icons>
-              <pagenums />
+              <pagenums></pagenums>
               <version>${project.version}</version>
-              <toc />
-              <idprefix />
+              <toc></toc>
+              <idprefix></idprefix>
               <idseparator>-</idseparator>
             </attributes>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.technologybrewery.fabric8</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.45-SNAPSHOT</version>
+  <version>0.45-tb-0.1.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>docker-maven-plugin</name>
@@ -52,7 +52,7 @@
   <scm>
     <connection>scm:git:git://github.com/TechnologyBrewery/docker-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/TechnologyBrewery/docker-maven-plugin.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>docker-maven-plugin-0.45-tb-0.1.0</tag>
     <url>git://github.com/TechnologyBrewery/docker-maven-plugin.git</url>
   </scm>
 
@@ -71,7 +71,7 @@
     <maven.version>3.8.1</maven.version>
     <minimum.maven.version>3.3.9</minimum.maven.version>
     <mockito.version>4.5.1</mockito.version>
-    <project.build.outputTimestamp>2024-02-17T15:18:53Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-07-23T21:25:47Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire.version>3.0.0-M2</surefire.version>
     <system-stubs.version>2.0.1</system-stubs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.fabric8</groupId>
+  <parent>
+    <groupId>org.technologybrewery</groupId>
+    <artifactId>parent</artifactId>
+    <version>9</version>
+  </parent>
+
+  <groupId>org.technologybrewery.fabric8</groupId>
   <artifactId>docker-maven-plugin</artifactId>
   <version>0.45-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
@@ -44,29 +50,16 @@
   </prerequisites>
 
   <scm>
-    <connection>scm:git:git://github.com/fabric8io/docker-maven-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/fabric8io/docker-maven-plugin.git</developerConnection>
+    <connection>scm:git:git://github.com/TechnologyBrewery/docker-maven-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/TechnologyBrewery/docker-maven-plugin.git</developerConnection>
     <tag>HEAD</tag>
-    <url>git://github.com/fabric8io/docker-maven-plugin.git</url>
+    <url>git://github.com/TechnologyBrewery/docker-maven-plugin.git</url>
   </scm>
 
   <issueManagement>
     <system>GitHub</system>
     <url>https://github.com/fabric8io/docker-maven-plugin/issues/</url>
   </issueManagement>
-
-  <distributionManagement>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <properties>
     <byte-buddy.version>1.12.10</byte-buddy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.technologybrewery.fabric8</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.45-tb-0.1.0</version>
+  <version>0.45-tb-0.1.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>docker-maven-plugin</name>
@@ -52,7 +52,7 @@
   <scm>
     <connection>scm:git:git://github.com/TechnologyBrewery/docker-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/TechnologyBrewery/docker-maven-plugin.git</developerConnection>
-    <tag>docker-maven-plugin-0.45-tb-0.1.0</tag>
+    <tag>HEAD</tag>
     <url>git://github.com/TechnologyBrewery/docker-maven-plugin.git</url>
   </scm>
 
@@ -71,7 +71,7 @@
     <maven.version>3.8.1</maven.version>
     <minimum.maven.version>3.3.9</minimum.maven.version>
     <mockito.version>4.5.1</mockito.version>
-    <project.build.outputTimestamp>2024-07-23T21:25:47Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-07-23T21:28:24Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire.version>3.0.0-M2</surefire.version>
     <system-stubs.version>2.0.1</system-stubs.version>
@@ -367,10 +367,10 @@
             <sourceDirectory>src/main/asciidoc</sourceDirectory>
             <attributes>
               <icons>font</icons>
-              <pagenums></pagenums>
+              <pagenums />
               <version>${project.version}</version>
-              <toc></toc>
-              <idprefix></idprefix>
+              <toc />
+              <idprefix />
               <idseparator>-</idseparator>
             </attributes>
           </configuration>

--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -35,7 +35,7 @@ import static io.fabric8.maven.docker.service.RegistryService.createCompleteAuth
  * @author roland
  * @since 28.07.14
  */
-@Mojo(name = "build", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "build", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class BuildMojo extends AbstractDockerMojo {
 
     public static final String DMP_PLUGIN_DESCRIPTOR = "META-INF/maven/io.fabric8/dmp-plugin";

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -245,27 +245,31 @@ public class BuildXService {
     protected String createBuilder(Path configPath, List<String> buildX, ImageConfiguration imageConfig, BuildDirs buildDirs) throws MojoExecutionException {
         BuildXConfiguration buildXConfiguration = imageConfig.getBuildConfiguration().getBuildX();
         String builderName = Optional.ofNullable(buildXConfiguration.getBuilderName()).orElse("maven");
-        String nodeName = buildXConfiguration.getNodeName();
-        Path builderPath = configPath.resolve(Paths.get("buildx", "instances", builderName));
-        if(Files.notExists(builderPath)) {
-            List<String> cmds = new ArrayList<>(buildX);
-            append(cmds, "create", "--driver", "docker-container", "--name", builderName);
-            if (nodeName != null) {
-                append(cmds, "--node", nodeName);
-            }
+        if ("default".equals(builderName)) {
+            logger.info("Using default builder with buildx - only single platforms will be supported");
+        } else {
+            String nodeName = buildXConfiguration.getNodeName();
+            Path builderPath = configPath.resolve(Paths.get("buildx", "instances", builderName));
+            if(Files.notExists(builderPath)) {
+                List<String> cmds = new ArrayList<>(buildX);
+                append(cmds, "create", "--driver", "docker-container", "--name", builderName);
+                if (nodeName != null) {
+                    append(cmds, "--node", nodeName);
+                }
 
-            if (buildXConfiguration.getDriverOpts() != null && !buildXConfiguration.getDriverOpts().isEmpty()) {
-                buildXConfiguration.getDriverOpts().forEach((key, value) -> append(cmds, "--driver-opt", key + '=' + value));
-            }
+                if (buildXConfiguration.getDriverOpts() != null && !buildXConfiguration.getDriverOpts().isEmpty()) {
+                    buildXConfiguration.getDriverOpts().forEach((key, value) -> append(cmds, "--driver-opt", key + '=' + value));
+                }
 
-            String buildConfig = buildXConfiguration.getConfigFile();
-            if(buildConfig != null) {
-                append(cmds, "--config",
-                buildDirs.getProjectPath(EnvUtil.resolveHomeReference(buildConfig)).toString());
-            }
-            int rc = exec.process(cmds);
-            if (rc != 0) {
-                throw new MojoExecutionException("Error status (" + rc + ") while creating builder " + builderName);
+                String buildConfig = buildXConfiguration.getConfigFile();
+                if (buildConfig != null) {
+                    append(cmds, "--config",
+                            buildDirs.getProjectPath(EnvUtil.resolveHomeReference(buildConfig)).toString());
+                }
+                int rc = exec.process(cmds);
+                if (rc != 0) {
+                    throw new MojoExecutionException("Error status (" + rc + ") while creating builder " + builderName);
+                }
             }
         }
         return builderName;

--- a/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
@@ -21,7 +21,7 @@ class ContainerHostConfigTest {
     @Test
     void testExtraHostsDoesNotResolve() {
         ContainerHostConfig hc = new ContainerHostConfig();
-        List<String> extraHosts = Collections.singletonList("database.pvt:ahostnamewhichreallyshouldnot.exist.zz");
+        List<String> extraHosts = Collections.singletonList("database.pvtahostnamewhichreallyshouldnot.exist.zz");
         Assertions.assertThrows(IllegalArgumentException.class, () -> hc.extraHosts(extraHosts));
     }
 


### PR DESCRIPTION
The purpose of this PR is to update the Build Mojo to be thread safe when using multi-threaded builds (mvnd). There was an issue with the `ContainerHostConfigTest`'s `testExtraHostsDoesNotResolve` unit test, so that was fixed as part of this PR too. 